### PR TITLE
Feat: API response에 runtime, mem usage 추가

### DIFF
--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -6,7 +6,10 @@ import { ConverterService } from './converter/converter.service';
 import { CarbonEmissionResponseDto } from './dto/carbon-emission-response.dto';
 import { ExecutionResult } from './db/entity/execution-result.entity';
 import { ConfigService } from '@nestjs/config';
-import { SECOND_TO_MILLISECOND } from './converter/converter.constants';
+import {
+  KILOBYTE_TO_MEGABYTE,
+  SECOND_TO_MILLISECOND,
+} from './converter/converter.constants';
 
 @Injectable()
 export class AppService {
@@ -49,6 +52,7 @@ export class AppService {
     return new CarbonEmissionResponseDto(
       this.converterService.convertCarbonEmission(emission),
       executionResult.runtime * SECOND_TO_MILLISECOND,
+      executionResult.memUsage / KILOBYTE_TO_MEGABYTE,
     );
   }
 

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -57,8 +57,8 @@ export class AppService {
   }
 
   async applyGreenAlgorithm(execution: ExecutionResult): Promise<number> {
-    const runtime = execution.runtime / 60 / 60 / 1000; // ms to h
-    const memUsage = execution.memUsage / 1024 / 1024; // B to GB
+    const runtime = execution.runtime / 60 / 60; // s to h
+    const memUsage = execution.memUsage / 1024 / 1024; // KB to GB
 
     return (
       (this.config.POC * execution.coreUsage + memUsage * 0.3725) *

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -48,7 +48,7 @@ export class AppService {
 
     return new CarbonEmissionResponseDto(
       this.converterService.convertCarbonEmission(emission),
-      executionResult.runtime / SECOND_TO_MILLISECOND,
+      executionResult.runtime * SECOND_TO_MILLISECOND,
     );
   }
 

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -7,7 +7,7 @@ import { CarbonEmissionResponseDto } from './dto/carbon-emission-response.dto';
 import { ExecutionResult } from './db/entity/execution-result.entity';
 import { ConfigService } from '@nestjs/config';
 import {
-  KILOBYTE_TO_MEGABYTE,
+  BYTE_TO_MEGABYTE,
   SECOND_TO_MILLISECOND,
 } from './converter/converter.constants';
 
@@ -52,7 +52,7 @@ export class AppService {
     return new CarbonEmissionResponseDto(
       this.converterService.convertCarbonEmission(emission),
       executionResult.runtime * SECOND_TO_MILLISECOND,
-      executionResult.memUsage / KILOBYTE_TO_MEGABYTE,
+      executionResult.memUsage / BYTE_TO_MEGABYTE,
     );
   }
 

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -6,6 +6,7 @@ import { ConverterService } from './converter/converter.service';
 import { CarbonEmissionResponseDto } from './dto/carbon-emission-response.dto';
 import { ExecutionResult } from './db/entity/execution-result.entity';
 import { ConfigService } from '@nestjs/config';
+import { SECOND_TO_MILLISECOND } from './converter/converter.constants';
 
 @Injectable()
 export class AppService {
@@ -47,6 +48,7 @@ export class AppService {
 
     return new CarbonEmissionResponseDto(
       this.converterService.convertCarbonEmission(emission),
+      executionResult.runtime / SECOND_TO_MILLISECOND,
     );
   }
 

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -7,7 +7,7 @@ import { CarbonEmissionResponseDto } from './dto/carbon-emission-response.dto';
 import { ExecutionResult } from './db/entity/execution-result.entity';
 import { ConfigService } from '@nestjs/config';
 import {
-  BYTE_TO_MEGABYTE,
+  KILOBYTE_TO_MEGABYTE,
   SECOND_TO_MILLISECOND,
 } from './converter/converter.constants';
 
@@ -52,7 +52,7 @@ export class AppService {
     return new CarbonEmissionResponseDto(
       this.converterService.convertCarbonEmission(emission),
       executionResult.runtime * SECOND_TO_MILLISECOND,
-      executionResult.memUsage / BYTE_TO_MEGABYTE,
+      executionResult.memUsage / KILOBYTE_TO_MEGABYTE,
     );
   }
 

--- a/backend/src/converter/converter.constants.ts
+++ b/backend/src/converter/converter.constants.ts
@@ -8,3 +8,4 @@ export const KILO_TO_MICRO = 1_000 * MICRO;
 export const KILO_TO_MILLI = MICRO;
 export const HOUR_TO_MICROSECOND = 60 * 60 * MICRO;
 export const SECOND_TO_MILLISECOND = 1_000;
+export const KILOBYTE_TO_MEGABYTE = 1024;

--- a/backend/src/converter/converter.constants.ts
+++ b/backend/src/converter/converter.constants.ts
@@ -4,6 +4,7 @@ export const CONVERTER_CONFIG = 'CONVERTER_CONFIG';
 export const emissionReferences = Object.values(Reference);
 
 export const MICRO = 1_000_000;
+export const MILLI = 1_000;
 export const KILO_TO_MICRO = 1_000 * MICRO;
 export const KILO_TO_MILLI = MICRO;
 export const SECOND_TO_MILLISECOND = 1_000;

--- a/backend/src/converter/converter.constants.ts
+++ b/backend/src/converter/converter.constants.ts
@@ -7,3 +7,4 @@ export const MICRO = 1_000_000;
 export const KILO_TO_MICRO = 1_000 * MICRO;
 export const KILO_TO_MILLI = MICRO;
 export const HOUR_TO_MICROSECOND = 60 * 60 * MICRO;
+export const SECOND_TO_MILLISECOND = 1_000;

--- a/backend/src/converter/converter.constants.ts
+++ b/backend/src/converter/converter.constants.ts
@@ -8,4 +8,4 @@ export const KILO_TO_MICRO = 1_000 * MICRO;
 export const KILO_TO_MILLI = MICRO;
 export const HOUR_TO_MICROSECOND = 60 * 60 * MICRO;
 export const SECOND_TO_MILLISECOND = 1_000;
-export const KILOBYTE_TO_MEGABYTE = 1024;
+export const BYTE_TO_MEGABYTE = 1024 * 1024;

--- a/backend/src/converter/converter.constants.ts
+++ b/backend/src/converter/converter.constants.ts
@@ -8,4 +8,4 @@ export const KILO_TO_MICRO = 1_000 * MICRO;
 export const KILO_TO_MILLI = MICRO;
 export const HOUR_TO_MICROSECOND = 60 * 60 * MICRO;
 export const SECOND_TO_MILLISECOND = 1_000;
-export const BYTE_TO_MEGABYTE = 1024 * 1024;
+export const KILOBYTE_TO_MEGABYTE = 1024;

--- a/backend/src/converter/converter.constants.ts
+++ b/backend/src/converter/converter.constants.ts
@@ -6,6 +6,6 @@ export const emissionReferences = Object.values(Reference);
 export const MICRO = 1_000_000;
 export const KILO_TO_MICRO = 1_000 * MICRO;
 export const KILO_TO_MILLI = MICRO;
-export const HOUR_TO_MICROSECOND = 60 * 60 * MICRO;
 export const SECOND_TO_MILLISECOND = 1_000;
+export const HOUR_TO_MILLISECOND = 60 * 60 * SECOND_TO_MILLISECOND;
 export const KILOBYTE_TO_MEGABYTE = 1024;

--- a/backend/src/converter/converter.service.ts
+++ b/backend/src/converter/converter.service.ts
@@ -3,10 +3,9 @@ import { CarbonEmissionConvertedResultDto } from 'src/dto/carbon-emission-conver
 import {
   CONVERTER_CONFIG,
   HOUR_TO_MILLISECOND,
-  KILO_TO_MICRO,
   KILO_TO_MILLI,
-  MICRO,
-} from './converter.constants';
+  MILLI,
+} from "./converter.constants";
 import { Reference } from './reference.enum';
 
 /**
@@ -32,12 +31,12 @@ export class ConverterService {
     carbonEmission: number,
   ): CarbonEmissionConvertedResultDto {
     // 1. 탄소 배출량 계산
-    // µgCO2e 단위
-    const convertedCarbonEmission: number = carbonEmission * MICRO;
+    // mgCO2e 단위
+    const convertedCarbonEmission: number = carbonEmission * MILLI;
 
     // 2. 전력 소모량 계산
-    // µWh 단위
-    const energy: number = (carbonEmission / this.config.CI) * KILO_TO_MICRO;
+    // mWh 단위
+    const energy: number = (carbonEmission / this.config.CI) * KILO_TO_MILLI;
 
     // 3. TV 시청 시간 계산
     // ms 단위
@@ -46,10 +45,10 @@ export class ConverterService {
       HOUR_TO_MILLISECOND;
 
     // 4. 승용차 주행 거리 계산
-    // µm 단위
+    // mm 단위
     const passageCar: number =
       (carbonEmission / this.config[Reference.DRIVING_DISTANCE]) *
-      KILO_TO_MICRO;
+      KILO_TO_MILLI;
 
     // 5. 지하철 이동 거리 계산
     // mm 단위
@@ -57,9 +56,9 @@ export class ConverterService {
       carbonEmission * this.config[Reference.SUBWAY_DISTANCE] * KILO_TO_MILLI;
 
     // 6. 사과 생산량 계산
-    // µg 단위
+    // mg 단위
     const appleProduction: number =
-      carbonEmission * this.config[Reference.APPLE_PRODUCTION] * MICRO;
+      carbonEmission * this.config[Reference.APPLE_PRODUCTION] * MILLI;
 
     return new CarbonEmissionConvertedResultDto(
       convertedCarbonEmission,

--- a/backend/src/converter/converter.service.ts
+++ b/backend/src/converter/converter.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { CarbonEmissionConvertedResultDto } from 'src/dto/carbon-emission-converted-result.dto';
 import {
   CONVERTER_CONFIG,
-  HOUR_TO_MICROSECOND,
+  HOUR_TO_MILLISECOND,
   KILO_TO_MICRO,
   KILO_TO_MILLI,
   MICRO,
@@ -40,10 +40,10 @@ export class ConverterService {
     const energy: number = (carbonEmission / this.config.CI) * KILO_TO_MICRO;
 
     // 3. TV 시청 시간 계산
-    // μs 단위
+    // ms 단위
     const tvWatchingTime: number =
       (carbonEmission / this.config[Reference.TV_WATCH_TIME]) *
-      HOUR_TO_MICROSECOND;
+      HOUR_TO_MILLISECOND;
 
     // 4. 승용차 주행 거리 계산
     // µm 단위

--- a/backend/src/dto/carbon-emission-converted-result.dto.ts
+++ b/backend/src/dto/carbon-emission-converted-result.dto.ts
@@ -4,7 +4,7 @@
  * @author Min Ho CHO
  */
 export class CarbonEmissionConvertedResultDto {
-  carbonFootPrint: number;
+  readonly carbonFootPrint: number;
 
   readonly energy: number;
 

--- a/backend/src/dto/carbon-emission-response.dto.ts
+++ b/backend/src/dto/carbon-emission-response.dto.ts
@@ -44,13 +44,13 @@ export class CarbonEmissionResponseDto {
     runtime: number,
     memoryUsage: number,
   ) {
-    this.runtime = runtime.toFixed(2) + 'ms';
-    this.memoryUsage = memoryUsage.toFixed(2) + 'MB';
-    this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + 'µgCO2e';
-    this.energy = dto.energy.toFixed(2) + 'µWh';
-    this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + 'ms';
-    this.passengerCarMileage = dto.passengerCarMileage.toFixed(2) + 'µm';
-    this.subwayTravelDistance = dto.subwayTravelDistance.toFixed(2) + 'mm';
-    this.appleProduction = dto.appleProduction.toFixed(2) + 'µg';
+    this.runtime = runtime.toFixed(2) + ' ms';
+    this.memoryUsage = memoryUsage.toFixed(2) + ' MB';
+    this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + ' µgCO2e';
+    this.energy = dto.energy.toFixed(2) + ' µWh';
+    this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + ' ms';
+    this.passengerCarMileage = dto.passengerCarMileage.toFixed(2) + ' µm';
+    this.subwayTravelDistance = dto.subwayTravelDistance.toFixed(2) + ' mm';
+    this.appleProduction = dto.appleProduction.toFixed(2) + ' µg';
   }
 }

--- a/backend/src/dto/carbon-emission-response.dto.ts
+++ b/backend/src/dto/carbon-emission-response.dto.ts
@@ -6,6 +6,9 @@ import { CarbonEmissionConvertedResultDto } from './carbon-emission-converted-re
  * @author Min Ho CHO
  */
 export class CarbonEmissionResponseDto {
+  @ApiProperty({ description: '런타임', example: '20.21ms' })
+  runtime: string;
+
   @ApiProperty({ description: '탄소 배출량', example: '20.02µgCO2e' })
   carbonFootPrint: string;
 
@@ -33,7 +36,8 @@ export class CarbonEmissionResponseDto {
   })
   readonly appleProduction: string;
 
-  constructor(dto: CarbonEmissionConvertedResultDto) {
+  constructor(dto: CarbonEmissionConvertedResultDto, runtime: number) {
+    this.runtime = runtime.toFixed(2) + 'ms';
     this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + 'µgCO2e';
     this.energy = dto.energy.toFixed(2) + 'µWh';
     this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + 'μs';

--- a/backend/src/dto/carbon-emission-response.dto.ts
+++ b/backend/src/dto/carbon-emission-response.dto.ts
@@ -18,7 +18,7 @@ export class CarbonEmissionResponseDto {
   @ApiProperty({ description: '전력 소모량', example: '30.02µWh' })
   readonly energy: string;
 
-  @ApiProperty({ description: 'TV 탄소 배출량과의 비교값', example: '25.21μs' })
+  @ApiProperty({ description: 'TV 탄소 배출량과의 비교값', example: '25.21ms' })
   readonly tvWatchingTime: string;
 
   @ApiProperty({

--- a/backend/src/dto/carbon-emission-response.dto.ts
+++ b/backend/src/dto/carbon-emission-response.dto.ts
@@ -45,7 +45,7 @@ export class CarbonEmissionResponseDto {
     memoryUsage: number,
   ) {
     this.runtime = runtime.toFixed(2) + 'ms';
-    this.memoryUsage = memoryUsage.toString(2) + 'MB';
+    this.memoryUsage = memoryUsage.toFixed(2) + 'MB';
     this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + 'µgCO2e';
     this.energy = dto.energy.toFixed(2) + 'µWh';
     this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + 'μs';

--- a/backend/src/dto/carbon-emission-response.dto.ts
+++ b/backend/src/dto/carbon-emission-response.dto.ts
@@ -46,11 +46,11 @@ export class CarbonEmissionResponseDto {
   ) {
     this.runtime = runtime.toFixed(2) + ' ms';
     this.memoryUsage = memoryUsage.toFixed(2) + ' MB';
-    this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + ' µgCO2e';
-    this.energy = dto.energy.toFixed(2) + ' µWh';
+    this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + ' mgCO2e';
+    this.energy = dto.energy.toFixed(2) + ' mWh';
     this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + ' ms';
-    this.passengerCarMileage = dto.passengerCarMileage.toFixed(2) + ' µm';
+    this.passengerCarMileage = dto.passengerCarMileage.toFixed(2) + ' mm';
     this.subwayTravelDistance = dto.subwayTravelDistance.toFixed(2) + ' mm';
-    this.appleProduction = dto.appleProduction.toFixed(2) + ' µg';
+    this.appleProduction = dto.appleProduction.toFixed(2) + ' mg';
   }
 }

--- a/backend/src/dto/carbon-emission-response.dto.ts
+++ b/backend/src/dto/carbon-emission-response.dto.ts
@@ -9,6 +9,9 @@ export class CarbonEmissionResponseDto {
   @ApiProperty({ description: '런타임', example: '20.21ms' })
   runtime: string;
 
+  @ApiProperty({ description: '메모리 사용량', example: '32.52MB' })
+  memoryUsage: string;
+
   @ApiProperty({ description: '탄소 배출량', example: '20.02µgCO2e' })
   carbonFootPrint: string;
 
@@ -36,8 +39,13 @@ export class CarbonEmissionResponseDto {
   })
   readonly appleProduction: string;
 
-  constructor(dto: CarbonEmissionConvertedResultDto, runtime: number) {
+  constructor(
+    dto: CarbonEmissionConvertedResultDto,
+    runtime: number,
+    memoryUsage: number,
+  ) {
     this.runtime = runtime.toFixed(2) + 'ms';
+    this.memoryUsage = memoryUsage.toString(2) + 'MB';
     this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + 'µgCO2e';
     this.energy = dto.energy.toFixed(2) + 'µWh';
     this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + 'μs';

--- a/backend/src/dto/carbon-emission-response.dto.ts
+++ b/backend/src/dto/carbon-emission-response.dto.ts
@@ -48,7 +48,7 @@ export class CarbonEmissionResponseDto {
     this.memoryUsage = memoryUsage.toFixed(2) + 'MB';
     this.carbonFootPrint = dto.carbonFootPrint.toFixed(2) + 'µgCO2e';
     this.energy = dto.energy.toFixed(2) + 'µWh';
-    this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + 'μs';
+    this.tvWatchingTime = dto.tvWatchingTime.toFixed(2) + 'ms';
     this.passengerCarMileage = dto.passengerCarMileage.toFixed(2) + 'µm';
     this.subwayTravelDistance = dto.subwayTravelDistance.toFixed(2) + 'mm';
     this.appleProduction = dto.appleProduction.toFixed(2) + 'µg';


### PR DESCRIPTION
(해당 이슈: #74)

## 구현사항
1. API response에 runtime을 추가 (단위: ms)
2. API response에 mem usage를 추가 (단위: MB)
3. 탄소 배출량 계산식 계산 과정 중 런타임 단위가 잘못되어있던 오류 수정